### PR TITLE
Fixing reporting for Windows 10

### DIFF
--- a/Controller/Include/rmiinternal.h
+++ b/Controller/Include/rmiinternal.h
@@ -103,6 +103,7 @@ typedef struct _RMI4_FINGER_CACHE
     UINT32 FingerSlotDirty;
     int FingerDownOrder[RMI4_MAX_TOUCHES];
     int FingerDownCount;
+    ULONG64 ScanTime;
 } RMI4_FINGER_CACHE;
 
 typedef struct _RMI4_CONTROLLER_CONTEXT

--- a/Controller/functions.c
+++ b/Controller/functions.c
@@ -396,6 +396,12 @@ Return Value:
 			Cache->FingerSlotValid &= ~(1 << i);
 		}
 	}
+
+	//
+	// Get current scan time (in 100us units)
+	//
+	ULONG64 QpcTimeStamp;
+	Cache->ScanTime = KeQueryInterruptTimePrecise(&QpcTimeStamp) / 1000;
 }
 
 NTSTATUS
@@ -879,8 +885,8 @@ Return Value:
 	//
 	// Get current scan time (in 100us units)
 	//
-	//ULONG64 QpcTimeStamp;
-	//Cache->ScanTime = KeQueryInterruptTimePrecise(&QpcTimeStamp) / 1000;
+	ULONG64 QpcTimeStamp;
+	Cache->ScanTime = KeQueryInterruptTimePrecise(&QpcTimeStamp) / 1000;
 }
 
 const PRMI_REGISTER_DESC_ITEM RmiGetRegisterDescItem(

--- a/Controller/report.c
+++ b/Controller/report.c
@@ -177,6 +177,11 @@ Return Value:
     hidTouch = &(HidReport->TouchReport);
 
     //
+    // There are only 16-bits for ScanTime, truncate it
+    //
+    hidTouch->InputReport.ScanTime = Cache->ScanTime & 0xFFFF;
+
+    //
     // Report the next available finger
     //
     currentlyReporting = Cache->FingerDownOrder[*TouchesReported];
@@ -195,7 +200,7 @@ Return Value:
 
     if (Cache->FingerSlot[currentlyReporting].fingerStatus)
     {
-        hidTouch->InputReport.bStatus = RANGE_FINGER_STATUS;
+        hidTouch->InputReport.bStatus = FINGER_STATUS;
     }
 
     (*TouchesReported)++;
@@ -221,7 +226,7 @@ Return Value:
 
         if (Cache->FingerSlot[currentlyReporting].fingerStatus)
         {
-            hidTouch->InputReport.bStatus2 = RANGE_FINGER_STATUS;
+            hidTouch->InputReport.bStatus2 = FINGER_STATUS;
         }
 
         (*TouchesReported)++;
@@ -237,6 +242,20 @@ Return Value:
     {
         hidTouch->InputReport.ActualCount = (UCHAR) TouchesTotal;
     }
+
+    /*Trace(
+        TRACE_LEVEL_NOISE,
+        TRACE_FLAG_REPORTING,
+        "ActualCount %d, Touch0 ContactId %u X %u Y %u Tip %u, Touch1 ContactId %u X %u Y %u Tip %u",
+        hidTouch->InputReport.ActualCount,
+        hidTouch->InputReport.ContactId,
+        hidTouch->InputReport.wXData,
+        hidTouch->InputReport.wYData,
+        hidTouch->InputReport.bStatus,
+        hidTouch->InputReport.ContactId2,
+        hidTouch->InputReport.wXData2,
+        hidTouch->InputReport.wYData2,
+        hidTouch->InputReport.bStatus2);*/
 }
 
 NTSTATUS

--- a/Device/hid.c
+++ b/Device/hid.c
@@ -41,25 +41,27 @@ const UCHAR gReportDescriptor[] = {
     0x75, 0x01,                         //     REPORT_SIZE (1)              
     0x95, 0x01,                         //     REPORT_COUNT (1)             
     0x81, 0x02,                         //       INPUT (Data,Var,Abs) 
-    0x09, 0x32,	                        //     USAGE (In Range)             
-    0x81, 0x02,                         //       INPUT (Data,Var,Abs)         
-    0x95, 0x06,                         //     REPORT_COUNT (6)  
+    0x95, 0x07,                         //     REPORT_COUNT (7)
     0x81, 0x03,                         //       INPUT (Cnst,Ary,Abs)
     0x75, 0x08,                         //     REPORT_SIZE (8)
-    0x09, 0x51,                         //     USAGE ( Temp Identifier)
+    0x09, 0x51,                         //     USAGE (Contact Identifier)
     0x95, 0x01,                         //     REPORT_COUNT (1)             
     0x81, 0x02,                         //       INPUT (Data,Var,Abs) 
     0x05, 0x01,                         //     USAGE_PAGE (Generic Desk..
-    0x26, TOUCH_DEVICE_RESOLUTION_X & 0xff, (TOUCH_DEVICE_RESOLUTION_X >> 8) & 0xff,  //     LOGICAL_MAXIMUM (4095)         
+    0x26, 
+TOUCH_DEVICE_RESOLUTION_X & 0xff, 
+(TOUCH_DEVICE_RESOLUTION_X >> 8) & 0xff,//     LOGICAL_MAXIMUM      
     0x75, 0x10,                         //     REPORT_SIZE (16)             
     0x55, 0x0e,                         //     UNIT_EXPONENT (-2)           
-    0x65, 0x33,                         //     UNIT (Inch,EngLinear)                  
+    0x65, 0x13,                         //     UNIT (Inch,EngLinear)
     0x09, 0x30,                         //     USAGE (X)                    
     0x35, 0x00,                         //     PHYSICAL_MINIMUM (0)         
-    0x46, 0x38, 0x04,                   //     PHYSICAL_MAXIMUM (1080)         
+    0x46, 0x1b, 0x01,                   //     PHYSICAL_MAXIMUM (283)       NOTE: ADJUST PHYSICAL MAXIMUM FOR X BASED ON TOUCH SCREEN DIMENSION (100ths of an inch)!
     0x81, 0x02,                         //       INPUT (Data,Var,Abs)         
-    0x46, 0x80, 0x07,                   //     PHYSICAL_MAXIMUM (1920)
-	0x26, TOUCH_DEVICE_RESOLUTION_Y & 0xff, (TOUCH_DEVICE_RESOLUTION_Y >> 8) & 0xff,  //     LOGICAL_MAXIMUM (4095)     
+    0x46, 0xf0, 0x01,                   //     PHYSICAL_MAXIMUM (496)       NOTE: ADJUST PHYSICAL MAXIMUM FOR Y BASED ON TOUCH SCREEN DIMENSION (100ths of an inch)!
+    0x26,
+TOUCH_DEVICE_RESOLUTION_Y & 0xff,
+(TOUCH_DEVICE_RESOLUTION_Y >> 8) & 0xff,//     LOGICAL_MAXIMUM
     0x09, 0x31,                         //     USAGE (Y)                
     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
     0xc0,                               //   END_COLLECTION
@@ -71,25 +73,27 @@ const UCHAR gReportDescriptor[] = {
     0x75, 0x01,                         //     REPORT_SIZE (1)              
     0x95, 0x01,                         //     REPORT_COUNT (1)             
     0x81, 0x02,                         //       INPUT (Data,Var,Abs) 
-    0x09, 0x32,	                        //     USAGE (In Range)             
-    0x81, 0x02,                         //     INPUT (Data,Var,Abs)         
-    0x95, 0x06,                         //     REPORT_COUNT (6)  
+    0x95, 0x07,                         //     REPORT_COUNT (7)
     0x81, 0x03,                         //       INPUT (Cnst,Ary,Abs)
     0x75, 0x08,                         //     REPORT_SIZE (8)
-    0x09, 0x51,                         //     USAGE ( Temp Identifier)
+    0x09, 0x51,                         //     USAGE (Contact Identifier)
     0x95, 0x01,                         //     REPORT_COUNT (1)             
     0x81, 0x02,                         //       INPUT (Data,Var,Abs) 
     0x05, 0x01,                         //     USAGE_PAGE (Generic Desk..
-    0x26, TOUCH_DEVICE_RESOLUTION_X & 0xff, (TOUCH_DEVICE_RESOLUTION_X >> 8) & 0xff,                   //     LOGICAL_MAXIMUM (4095)       
+    0x26,
+TOUCH_DEVICE_RESOLUTION_X & 0xff,
+(TOUCH_DEVICE_RESOLUTION_X >> 8) & 0xff,//     LOGICAL_MAXIMUM 
     0x75, 0x10,                         //     REPORT_SIZE (16)             
     0x55, 0x0e,                         //     UNIT_EXPONENT (-2)           
-    0x65, 0x33,                         //     UNIT (Inch,EngLinear)                  
+    0x65, 0x13,                         //     UNIT (Inch,EngLinear)
     0x09, 0x30,                         //     USAGE (X)                    
     0x35, 0x00,                         //     PHYSICAL_MINIMUM (0)         
-    0x46, 0x38, 0x04,                   //     PHYSICAL_MAXIMUM (1080)         
+    0x46, 0x1b, 0x01,                   //     PHYSICAL_MAXIMUM (283)       NOTE: ADJUST PHYSICAL MAXIMUM FOR X BASED ON TOUCH SCREEN DIMENSION (100ths of an inch)!
     0x81, 0x02,                         //       INPUT (Data,Var,Abs)         
-    0x46, 0x80, 0x07,                   //     PHYSICAL_MAXIMUM (1920)
-	0x26, TOUCH_DEVICE_RESOLUTION_Y & 0xff, (TOUCH_DEVICE_RESOLUTION_Y >> 8) & 0xff,  //     LOGICAL_MAXIMUM (4095)   
+    0x46, 0xf0, 0x01,                   //     PHYSICAL_MAXIMUM (496)       NOTE: ADJUST PHYSICAL MAXIMUM FOR Y BASED ON TOUCH SCREEN DIMENSION (100ths of an inch)!
+    0x26,
+TOUCH_DEVICE_RESOLUTION_Y & 0xff,
+(TOUCH_DEVICE_RESOLUTION_Y >> 8) & 0xff,//     LOGICAL_MAXIMUM
     0x09, 0x31,                         //     USAGE (Y)                    
     0x81, 0x02,                         //       INPUT (Data,Var,Abs)
     0xc0,                               //   END_COLLECTION
@@ -97,6 +101,14 @@ const UCHAR gReportDescriptor[] = {
     0x09, 0x54,	                        //   USAGE (Actual count)
     0x95, 0x01,                         //   REPORT_COUNT (1)
     0x75, 0x08,                         //   REPORT_SIZE (8)    
+    0x81, 0x02,                         //     INPUT (Data,Var,Abs)
+    0x55, 0x0C,                         //   UNIT_EXPONENT (-4)
+    0x66, 0x01, 0x10,                   //   UNIT (Seconds)
+    0x47, 0xff, 0xff, 0x00, 0x00,       //   PHYSICAL_MAXIMUM (65535)
+    0x27, 0xff, 0xff, 0x00, 0x00,       //   LOGICAL_MAXIMUM (65535)
+    0x09, 0x56,                         //   USAGE (Scan Time)
+    0x95, 0x01,                         //   REPORT_COUNT (1)
+    0x75, 0x10,                         //   REPORT_SIZE (16)
     0x81, 0x02,                         //     INPUT (Data,Var,Abs)
     0x85, REPORTID_MAX_COUNT,           //   REPORT_ID (Feature)              
     0x09, 0x55,                         //   USAGE(Maximum Count)
@@ -151,8 +163,8 @@ const UCHAR gReportDescriptor[] = {
 	0x85, REPORTID_CAPKEY,				//   REPORT_ID
 	0x05, 0x07,							//   USAGE_PAGE (Keyboard)
 	0x09, 0xe3,							//   USAGE (Keyboard Left GUI) - Start/Home
-	0x09, 0x3A,							//   USAGE (Keyboard F1)	 - Search
-	0x09, 0x29,							//   USAGE (Keyboard ESCAPE) - Back
+	0x09, 0x3A,							//   USAGE (Keyboard F1)	   - Search
+	0x09, 0x29,							//   USAGE (Keyboard ESCAPE)   - Back
 	0x15, 0x00,							//   LOGICAL_MINIMUM (0)
 	0x25, 0x01,							//   LOGICAL_MAXIMUM (1)
 	0x75, 0x01,							//   REPORT_SIZE (1)

--- a/Include/config.h
+++ b/Include/config.h
@@ -6,7 +6,7 @@
 #define TOUCH_PHYSICAL_RESOLUTION_Y     1259  //12.59
 
 
-//comment next line to use 10 fingers dara registers status
+//comment next line to use 10 fingers data registers status
 //needs for L630 
 #define USE_SHORT_F11_DATA_REGISTERS_STATUS
 

--- a/Include/controller.h
+++ b/Include/controller.h
@@ -51,8 +51,6 @@
 #define MOUSE_MOVE_TOUCH_ABSOLUTE       0x8000
 
 #define FINGER_STATUS                   0x01 // finger down
-#define RANGE_STATUS                    0x02 // in range
-#define RANGE_FINGER_STATUS             0x03 // finger down (range + finger)
 
 #define KEY_DOWN_START                  (1 << 0)
 #define KEY_DOWN_SEARCH                 (1 << 1)
@@ -87,8 +85,9 @@ typedef struct _HID_TOUCH_REPORT
             USHORT wXData2;
             USHORT wYData2;
             UCHAR  ActualCount;
+            USHORT ScanTime;
         } InputReport;
-        UCHAR RawInput[13];
+        UCHAR RawInput[15];
     };
 } HID_TOUCH_REPORT, *PHID_TOUCH_REPORT;
 


### PR DESCRIPTION
Removed finger range reporting as it is unused by MS abi and added back ScanTime reporting which is mandatory with desktop. Fixes windows 10 issues.